### PR TITLE
Should not validate that ComplexType#custom is a boolean

### DIFF
--- a/src/a40_entityMetadata.js
+++ b/src/a40_entityMetadata.js
@@ -2104,7 +2104,7 @@ var ComplexType = (function () {
             .whereParam("namespace").isString().isOptional().withDefault("")
             .whereParam("dataProperties").isOptional()
             .whereParam("isComplexType").isOptional().isBoolean()   // needed because this ctor can get called from the addEntityType method which needs the isComplexType prop
-            .whereParam("custom").isOptional().isBoolean()
+            .whereParam("custom").isOptional()
             .applyAll(this);
 
         this.name = qualifyTypeName(this.shortName, this.namespace);


### PR DESCRIPTION
I'm fairly new to breeze, so this is likely a lack of understanding on my part, but I'm having trouble with the `ComplexType` constructor trying to validate that the `custom` attribute is a Boolean.

The docs above the constructor and other instances of the `custom` attribute indicate that it should be an object.

I put together a rudimentary pull request to correct this behavior, assuming it is incorrect, but I have not run any unit tests against the change.
