### PR TITLE
Added eTag to WebApiOData batch requests as If-Match HTTP request

### DIFF
--- a/src/b00_breeze.dataService.odata.js
+++ b/src/b00_breeze.dataService.odata.js
@@ -225,6 +225,10 @@
             var aspect = entity.entityAspect;
             id = id + 1; // we are deliberately skipping id=0 because Content-ID = 0 seems to be ignored.
             var request = { headers: { "Content-ID": id, "DataServiceVersion": "2.0" } };
+            // add etag to header if present in entity
+            if (entity.eTag !== undefined){
+                request.headers["If-Match"] = entity.eTag;
+            }
             contentKeys[id] = entity;
             if (aspect.entityState.isAdded()) {
                 request.requestUri = routePrefix + entity.entityType.defaultResourceName;


### PR DESCRIPTION
At present, the requests created for the batch sent to the WebAPI OData implementation does not include an "If-Match" HTTP request header. Many services implement this to ensure the desired version of the item on the server is being updated. 

This pull extends the batch creation to add the "If-Match" header to the header request of each batch if it is found within the specified entity.
