### PR TITLE
Bug fix missing resolveProperty method

### DIFF
--- a/build/breeze.debug.js
+++ b/build/breeze.debug.js
@@ -8887,6 +8887,16 @@ var NavigationProperty = (function () {
         
     proto.isDataProperty = false;
     proto.isNavigationProperty = true;
+    
+    proto.resolveProperty = function (propName) {
+        var result = this[propName];
+        var baseProp = this.baseProperty;
+        while (result == undefined && baseProp != null) {
+            result = baseProp[propName];
+            baseProp = baseProp.baseProperty;
+        }
+        return result;
+    }
 
     __extend(proto, DataProperty.prototype, [
         "formatName", "getAllValidators"


### PR DESCRIPTION
Navigation property had no resolveProperty method. Copied from DataProperty.

TypeError: undefined is not a function
    at rootContext.displayName (http://localhost:12500/Scripts/breeze.debug.js:2021:41)
    at http://localhost:12500/Scripts/breeze.debug.js:2840:28
    at String.replace (native)
    at formatTemplate (http://localhost:12500/Scripts/breeze.debug.js:2831:25)
    at proto.getMessage (http://localhost:12500/Scripts/breeze.debug.js:2260:24)
    at proto.validate (http://localhost:12500/Scripts/breeze.debug.js:2230:71)
    at validate (http://localhost:12500/Scripts/breeze.debug.js:4183:28)
    at http://localhost:12500/Scripts/breeze.debug.js:4090:22
    at Array.forEach (native)
    at http://localhost:12500/Scripts/breeze.debug.js:4089:49
