### PR TITLE
jspm support

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -13,5 +13,10 @@
     "gulp-uglify": "^1.0.1",
     "through": "2.3.6 ",
     "yuidocjs": "^0.3.50"
-  }
+  },
+  "directories": { 
+    "lib": "build"
+  },
+  "main": "breeze.debug.js",
+  "format": "global"
 }


### PR DESCRIPTION
These three props are [extensions to the npm's package.json spec](https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm) and are used by jspm to give users a seamless install & import experience when the default logic doesn't work with a particular package.

With these changes users will be able to install breeze via the [jspm](http://jspm.io/) CLI:

```bash
jspm install npm:breeze-client
```

And then be able to import breeze in their ES6 app code using the same identifier:

```javascript
import breeze from 'breeze-client';
```