### PR TITLE
AMD ReferenceError bug fix

### DIFF
--- a/src/b00_breeze.ajax.angular.js
+++ b/src/b00_breeze.ajax.angular.js
@@ -7,7 +7,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"]) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.ajax.jQuery.js
+++ b/src/b00_breeze.ajax.jQuery.js
@@ -7,7 +7,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"]) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.dataService.odata.js
+++ b/src/b00_breeze.dataService.odata.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.dataService.webApi.js
+++ b/src/b00_breeze.dataService.webApi.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.modelLibrary.backingStore.js
+++ b/src/b00_breeze.modelLibrary.backingStore.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.modelLibrary.ko.js
+++ b/src/b00_breeze.modelLibrary.ko.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }
@@ -91,13 +91,15 @@
 
     var stype = proto.entityType || proto.complexType;
     var es5Descriptors = {};
+    vor found = false;
     stype.getProperties().forEach(function (prop) {
       var propDescr = getES5PropDescriptor(proto, prop.name);
       if (propDescr) {
         es5Descriptors[prop.name] = propDescr;
+        found=true;
       }
     })
-    if (!__isEmpty(es5Descriptors)) {
+    if (found) {
       var extra = stype._extra;
       extra.es5Descriptors = es5Descriptors;
       stype._koDummy = ko.observable(null);

--- a/src/b00_breeze.uriBuilder.json.js
+++ b/src/b00_breeze.uriBuilder.json.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }

--- a/src/b00_breeze.uriBuilder.odata.js
+++ b/src/b00_breeze.uriBuilder.odata.js
@@ -4,7 +4,7 @@
   } else if (typeof require === "function" && typeof exports === "object" && typeof module === "object") {
     // CommonJS or Node: hard-coded dependency on "breeze"
     factory(require("breeze"));
-  } else if (typeof define === "function" && define["amd"] && !breeze) {
+  } else if (typeof define === "function" && define["amd"] && typeof breeze === "undefined") {
     // AMD anonymous module with hard-coded dependency on "breeze"
     define(["breeze"], factory);
   }


### PR DESCRIPTION
Hi,

in AMD environment (requirejs) breeze in not contained in context object so testing !breeze gave me "Uncaught ReferenceError: breeze is not defined". Also in breeze.modelLibrary.ko.js there is a call to 1 hidden core function (__isEmpty) that, again, in AMD environment is missing. I replace the code with simple set variable if found and check found variable.
