### PR TITLE
Add custom query option support to webapi odata

### DIFF
--- a/src/b00_breeze.uriBuilder.odata.js
+++ b/src/b00_breeze.uriBuilder.odata.js
@@ -46,6 +46,15 @@
     if (entityQuery.inlineCountEnabled) {
       queryOptions["$inlinecount"] = "allpages";
     }
+    
+    //add custom query option support to webapi odata
+    if (entityQuery.parameters !== null && typeof entityQuery.parameters === 'object') {
+      for (var param in entityQuery.parameters) {
+        if (/^([^\$].*)$/.test(param)) {
+          queryOptions[param] = entityQuery.parameters[param];
+        }
+      }
+    }
 
     var qoText = toQueryOptionsString(queryOptions);
     return entityQuery.resourceName + qoText;


### PR DESCRIPTION
Since the optional parameters from .withParameter doesn't get appended to the webapi call, this could be a possible solution for #19 