### PR TITLE
Allow access to angular config via httpResponse object

### DIFF
--- a/src/b00_breeze.ajax.angular.js
+++ b/src/b00_breeze.ajax.angular.js
@@ -109,6 +109,7 @@
         config: config,
         data: data,
         getHeaders: headers,
+        ngConfig: xconfig,
         status: status,
         statusText: statusText
       };
@@ -125,6 +126,7 @@
         config: config,
         data: data,
         getHeaders: headers,
+        ngConfig: xconfig,
         status: status,
         statusText: statusText
       };


### PR DESCRIPTION
Angular $httpInterceptors can be used for timing requests, or sequencing requests by adding information to the config programatically.  

Breeze should allow access to this information through its httpResponse object.