### PR TITLE
"Q is not defined" fix

### DIFF
--- a/src/b00_breeze.dataService.odata.js
+++ b/src/b00_breeze.dataService.odata.js
@@ -55,7 +55,7 @@
 
   proto.executeQuery = function (mappingContext) {
 
-    var deferred = Q.defer();
+    var deferred = breeze.Q.defer();
     var url = this.getAbsoluteUrl(mappingContext.dataService, mappingContext.getUrl());
 
     OData.read({
@@ -80,7 +80,7 @@
 
   proto.fetchMetadata = function (metadataStore, dataService) {
 
-    var deferred = Q.defer();
+    var deferred = breeze.Q.defer();
 
     var serviceName = dataService.serviceName;
     //var url = dataService.qualifyUrl('$metadata');
@@ -129,7 +129,7 @@
 
   proto.saveChanges = function (saveContext, saveBundle) {
     var adapter = saveContext.adapter = this;
-    var deferred = Q.defer();
+    var deferred = breeze.Q.defer();
     //saveContext.routePrefix = adapter.getRoutePrefix(saveContext.dataService);
     //var url = saveContext.dataService.qualifyUrl("$batch");
     saveContext.routePrefix = adapter.getAbsoluteUrl(saveContext.dataService, ''); 


### PR DESCRIPTION
When using breeze.dataService.odata.js adapter as a separate library (together with breeze.base.debug.js), there is no global Q variable, hence the issue. In three locations, Q
was replaced with breeze.Q.

If you wish I can create a test case for it.