### PR TITLE
Fix getTuples inheritance

### DIFF
--- a/src/a50_entityManager.js
+++ b/src/a50_entityManager.js
@@ -2430,14 +2430,21 @@ var EntityManager = (function () {
 
 
   UnattachedChildrenMap.prototype.getTuples = function (parentEntityKey) {
+    var allTuples = [];
     var tuples = this.map[parentEntityKey.toString()];
+    if (tuples) {
+      allTuples = allTuples.concat(tuples);
+    }
     var entityType = parentEntityKey.entityType;
-    while (!tuples && entityType.baseEntityType) {
+    while (entityType.baseEntityType) {
       entityType = entityType.baseEntityType;
       var baseKey = parentEntityKey.toString(entityType);
       tuples = this.map[baseKey];
+      if (tuples) {
+        allTuples = allTuples.concat(tuples);
+      }
     }
-    return tuples;
+    return (allTuples.length) ? allTuples : undefined;
   };
 
   return ctor;


### PR DESCRIPTION
getTuples did not consider entities inheritance.

During the _linkRelatedEntities process, my entities where only linking related entities for the first level of inheritance found in getTuples.
