### PR TITLE
Extra ? or & were getting added to OData queries

### DIFF
--- a/src/b00_breeze.dataService.odata.js
+++ b/src/b00_breeze.dataService.odata.js
@@ -112,7 +112,7 @@
     }
 
     // Add query params if .withParameters was used
-    if (mappingContext.query.parameters) {
+    if (! __isEmpty(mappingContext.query.parameters)) {
       var paramString = toQueryString(mappingContext.query.parameters);
       var sep = url.indexOf("?") < 0 ? "?" : "&";
       url = url + sep + paramString;


### PR DESCRIPTION
mappingContext.query.parameters will always be non-null.. So added a check for non-empty to avoid the same.