### PR TITLE
"__extend is not defined" fix

### DIFF
--- a/src/b00_breeze.dataService.odata.js
+++ b/src/b00_breeze.dataService.odata.js
@@ -120,7 +120,7 @@
 
     OData.read({
           requestUri: url,
-          headers: __extend({}, this.headers)
+          headers: core.extend({}, this.headers)
         },
         function (data, response) {
           var inlineCount;
@@ -162,7 +162,7 @@
       url = this.getAbsoluteUrl(dataService, '$metadata');
     }
 
-    var mheaders = __extend({}, this.headers);
+    var mheaders = core.extend({}, this.headers);
     mheaders.Accept = 'application/*; odata.metadata=full';
 
     // OData.read(url,
@@ -228,7 +228,7 @@
     var contentKeys = saveContext.contentKeys;
 
     OData.request({
-      headers: __extend({}, this.headers),
+      headers: core.extend({}, this.headers),
       requestUri: url,
       method: "POST",
       data: requestData


### PR DESCRIPTION
The adapter is trying to use __extend function and failing, which is
actually defined on core as extend function. The error only appears in
when using breeze.base.debug.js with separate adapters, not with
breeze.debug.js.

Example project that compares both original & fixed versions of the file:
https://github.com/forCrowd/Labs-BreezeJS-ODataAdapterFix