### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-#![BreezeJS](http://breeze.github.io/images/logos/BreezeJsB.png "BreezeJS")
+# ![BreezeJS](http://breeze.github.io/images/logos/BreezeJsB.png "BreezeJS")
 
-###Welcome to "**Breeze for JavaScript**" by [**IdeaBlade**](http://www.ideablade.com "IdeaBlade website"). 
+### Welcome to "**Breeze for JavaScript**" by [**IdeaBlade**](http://www.ideablade.com "IdeaBlade website"). 
 
 This repository holds the Breeze assets **for HTML/JS client development**. 
 
 For documentation: http://breeze.github.io/doc-js/
 
-##Support
+## Support
 
 **For technical questions, please go to [StackOverflow with the tag "breeze"](http://stackoverflow.com/questions/tagged/breeze?sort=newest "BreezeJS on StackOverflow").**
 
@@ -26,7 +26,7 @@ Please post your [**feature suggestions** to our User Voice site](https://breeze
 
 <a href="mailto:breeze@ideablade.com/?subject=Tell me about professional services" title="Professional Services">Learn about IdeaBlade's <strong>professional services</strong></a> from training through application development</a>.
 
-##Documentation
+## Documentation
 
 [**Samples** and Breeze-related code for server development](https://github.com/Breeze "Breeze sample repositories on github") reside in sibling Breeze repositories such as [breeze.js.samples](https://github.com/Breeze/breeze.js.samples "BreezeJS samples"). Documentation on the samples at: http://breeze.github.io/doc-samples/
 

--- a/test/vendor/README.md
+++ b/test/vendor/README.md
@@ -1,4 +1,4 @@
-#Breeze.Js Test Vendor
+# Breeze.Js Test Vendor
 
 This directory holds specific versions of 3rd party JavaScript libraries that we include in tests for Breeze compatibility.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
