### PR TITLE
Add support for Vue.js array reactivity

### DIFF
--- a/src/a25_observableArray.js
+++ b/src/a25_observableArray.js
@@ -11,7 +11,13 @@
       return this.length;
     }
     this._beforeChange();
-    var result = Array.prototype.push.apply(this, goodAdds);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.push) {
+        result = objPrototype.push.apply(this, goodAdds)
+    } else {
+        result = Array.prototype.push.apply(this, goodAdds);
+    }
     processAdds(this, goodAdds);
     return result;
   };
@@ -22,7 +28,13 @@
     }
     var goodAdds = __arraySlice(arguments);
     this._beforeChange();
-    var result = Array.prototype.push.apply(this, goodAdds);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.push) {
+        result = objPrototype.push.apply(this, goodAdds)
+    } else {
+        result = Array.prototype.push.apply(this, goodAdds);
+    }
     processAdds(this, goodAdds);
     return result;
   };
@@ -33,21 +45,39 @@
       return this.length;
     }
     this._beforeChange();
-    var result = Array.prototype.unshift.apply(this, goodAdds);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.unshift) {
+        result = objPrototype.unshift.apply(this, goodAdds)
+    } else {
+        result = Array.prototype.unshift.apply(this, goodAdds);
+    }
     processAdds(this, __arraySlice(goodAdds));
     return result;
   };
 
   mixin.pop = function () {
     this._beforeChange();
-    var result = Array.prototype.pop.apply(this);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.pop) {
+        result = objPrototype.pop.apply(this)
+    } else {
+        result = Array.prototype.pop.apply(this);
+    }
     processRemoves(this, [result]);
     return result;
   };
 
   mixin.shift = function () {
     this._beforeChange();
-    var result = Array.prototype.shift.apply(this);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.shift) {
+        result = objPrototype.shift.apply(this)
+    } else {
+        result = Array.prototype.shift.apply(this);
+    }
     processRemoves(this, [result]);
     return result;
   };
@@ -56,7 +86,13 @@
     var goodAdds = this._getGoodAdds(__arraySlice(arguments, 2));
     var newArgs = __arraySlice(arguments, 0, 2).concat(goodAdds);
     this._beforeChange();
-    var result = Array.prototype.splice.apply(this, newArgs);
+    var result;
+    var objPrototype = Object.getPrototypeOf(this);
+    if (objPrototype.splice) {
+        result = objPrototype.splice.apply(this, newArgs)
+    } else {
+        result = Array.prototype.splice.apply(this, newArgs);
+    }
     processRemoves(this, result);
 
     if (goodAdds.length) {


### PR DESCRIPTION
Vue.js array reactivity is currently broken when using Breeze.js due to
observableArray mixins (push, pop, shift, unshift, splice) calling
the corresponding Array.prototype function directly and ignoring
any other prototypes that override array functions between it and
Array.prototype. Vue.js hooks into these functions at a low level
to react to array changes, and calls the original. When Vue and Breeze
are used together, Breeze will always create arrays that have Vue hooks
before adding it's own. This change simply modifies Breeze's array
mixins to to call the corresponding method in its prototype if available
instead of going straight to Array.prototype. This allows Breeze and Vue
arrays to play nicely together and work as intended.