### PR TITLE
Fix issue with missing foreign key

### DIFF
--- a/src/a40_entityMetadata.js
+++ b/src/a40_entityMetadata.js
@@ -3069,6 +3069,10 @@ var NavigationProperty = (function () {
     var fkPropCollection = parentEntityType.foreignKeyProperties;
 
     fkProps.forEach(function (dp) {
+      if (!dp) {
+        return;
+      }
+
       __arrayAddItemUnique(fkPropCollection, dp);
       dp.relatedNavigationProperty = np;
       // now update the inverse


### PR DESCRIPTION
I have a situation where there is no foreign key on the navigation property's parent type, so an exception is being thrown when parsing the metadata. This just adds a null check and skip for this condition. Thanks!